### PR TITLE
  Add Symfony 4 compatibility information, require symfony/console

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Application extends BundleApplication
 {
+    /** @var string[] */
     protected $excludedCommands = [];
 
     public function addExcludedCommand(string $name): self
@@ -31,7 +32,7 @@ class Application extends BundleApplication
         return $return;
     }
 
-    public function add(Command $command)
+    public function add(Command $command): ?Command
     {
         if (
             count(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![version](https://img.shields.io/badge/version-1.1.1-green.svg)](https://github.com/huttopia/console-bundle)
-[![symfony](https://img.shields.io/badge/symfony/symfony-^2.3%20||%20^3.0-blue.svg)](https://symfony.com)
-![Lines](https://img.shields.io/badge/code%20lines-370-green.svg)
+[![symfony](https://img.shields.io/badge/symfony/symfony-^2.3%20||%20^3.0%20||%20^4.0-blue.svg)](https://symfony.com)
+![Lines](https://img.shields.io/badge/code%20lines-366-green.svg)
 ![Total Downloads](https://poser.pugx.org/huttopia/console-bundle/downloads)
 
 # ConsoleBundle

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,7 @@
     },
     "require": {
         "php": ">=7.1.2",
-        "symfony/framework-bundle": "^2.3|^3.0|^4.0"
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:huttopia/console-bundle.git"
-        }
-    ]
+        "symfony/framework-bundle": "^2.3|^3.0|^4.0",
+        "symfony/console": "^2.3|^3.0|^4.0"
+    }
 }


### PR DESCRIPTION
Salut Huttopia !

Voilà quelques modifications simplettes :
 * Ajout de l'indication que ce bundle est compatible avec Symfony 4 dans les badges du `README.md`
 * Ajout de `symfony/console` dans les `require` du `composer.json`
 * Petit PHP7 style qui manquait